### PR TITLE
MH-128: Enabled debug-toolbar in dev env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
     volumes:
       - ./.config/nginx/dev:/etc/nginx/conf.d
       - .:/modularhistory
+    networks:
+      default:
+        ipv4_address: 172.27.0.5
 
   celery:
     command: sh .config/init/celery.sh
@@ -64,7 +67,6 @@ services:
     depends_on:
       - postgres
       - redis
-      - mongo
     env_file: .env
     environment:
       <<: *common-env-vars

--- a/modularhistory/config/_debug_toolbar.py
+++ b/modularhistory/config/_debug_toolbar.py
@@ -19,7 +19,7 @@ def show_toolbar(request: HttpRequest) -> bool:
         request.user.is_superuser,
     )
     disqualifiers = (
-        [settings.TESTING]
+        settings.TESTING,
     )
     if any(conditions) and not any(disqualifiers):
         return True

--- a/modularhistory/config/_debug_toolbar.py
+++ b/modularhistory/config/_debug_toolbar.py
@@ -11,20 +11,15 @@ https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html
 from django.conf import settings
 from django.http import HttpRequest
 
-from modularhistory.constants.environments import Environments
-
 
 def show_toolbar(request: HttpRequest) -> bool:
     """Determine whether to display the debug toolbar."""
     conditions = (
-        settings.DEBUG
-        and request.META.get('REMOTE_ADDR', None) in settings.INTERNAL_IPS,
+        settings.DEBUG and request.META.get('REMOTE_ADDR', None) in settings.INTERNAL_IPS,
         request.user.is_superuser,
     )
     disqualifiers = (
-        settings.TESTING,
-        # disable toolbar in Dockerized dev environment to avoid errors; TODO: fix?
-        settings.ENVIRONMENT == Environments.DEV and settings.DOCKERIZED,
+        [settings.TESTING]
     )
     if any(conditions) and not any(disqualifiers):
         return True

--- a/modularhistory/config/debug_toolbar.py
+++ b/modularhistory/config/debug_toolbar.py
@@ -2,7 +2,7 @@
 
 # https://docs.djangoproject.com/en/3.1/ref/settings#s-internal-ips
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#configuring-internal-ips
-INTERNAL_IPS = ['127.0.0.1']
+INTERNAL_IPS = ['127.0.0.1', '172.27.0.5']
 
 # https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html
 DEBUG_TOOLBAR_CONFIG = {


### PR DESCRIPTION
To enable: removed disqualifier for being dockerized and added static ip of dev service to internal ips

Also removed mongodb requirement for django service