### PR TITLE
MH-130: Fix duplicate n queries on search form entities selections

### DIFF
--- a/apps/entities/models/entity.py
+++ b/apps/entities/models/entity.py
@@ -91,7 +91,7 @@ class Entity(
         verbose_name_plural = 'Entities'
         ordering = ['name']
 
-    searchable_fields = ['name', 'aliases', 'description']
+    searchable_fields = ['id', 'type', 'name', 'aliases', 'description']
     serializer = EntitySerializer
     slug_base_field = 'unabbreviated_name'
 

--- a/apps/entities/models/entity.py
+++ b/apps/entities/models/entity.py
@@ -91,7 +91,7 @@ class Entity(
         verbose_name_plural = 'Entities'
         ordering = ['name']
 
-    searchable_fields = ['id', 'type', 'name', 'aliases', 'description']
+    searchable_fields = ['name', 'aliases', 'description']
     serializer = EntitySerializer
     slug_base_field = 'unabbreviated_name'
 

--- a/apps/search/forms.py
+++ b/apps/search/forms.py
@@ -89,7 +89,7 @@ class SearchForm(forms.Form):
         )
 
         self.fields['entities'] = forms.ModelMultipleChoiceField(
-            queryset=(entities or Entity.objects.all().only(*Entity.searchable_fields)),
+            queryset=(entities or Entity.objects.all().only('id', 'type', *Entity.searchable_fields)),
             widget=Select2MultipleWidget,
             required=False,
         )


### PR DESCRIPTION
`id` and `type` was missing from searchable_fields array which was causing n queries