### PR TITLE
Fix `next` CPU usage

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -64,13 +64,4 @@ module.exports = {
     }
     return config;
   },
-  webpackDevMiddleware: (config) => {
-    // Solve compiling problem within Docker
-    config.watchOptions = {
-      poll: 2000,
-      aggregateTimeout: 200,
-      ignored: [".next/", "node_modules/"],
-    };
-    return config;
-  },
 };


### PR DESCRIPTION
We added this poll config a while back for reasons which shall not be discussed. I think the performance issues started when `.npm` was added to the `frontend/` directory, but was not added to the ignored paths in the config. Anyway, we don't need it anymore.