### PR TITLE
Reduce ES memory limits in dev

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -101,6 +101,7 @@ services:
       - "9200:9200"
     environment:
       - ELASTIC_PASSWORD=test
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   kibana:
     ports:


### PR DESCRIPTION
We experienced some crashes before when lowering this value, but everything seems to work fine now. It might be good to test this change locally before approving, but it's also easy to fix if it causes problems.