### PR TITLE
Allow unverified propositions in API results

### DIFF
--- a/apps/propositions/api/views.py
+++ b/apps/propositions/api/views.py
@@ -10,7 +10,7 @@ from apps.propositions.models import Proposition
 class PropositionViewSet(ModelViewSet):
     """API endpoint for viewing and editing propositions."""
 
-    queryset = Proposition.objects.filter(type='propositions.conclusion', verified=True)
+    queryset = Proposition.objects.filter(type='propositions.conclusion')
     lookup_field = 'slug'
     serializer_class = PropositionDrfSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]


### PR DESCRIPTION
There are at least several module links which are broken right now since unverified propositions return 404 from the API.