### PR TITLE
Propositions API hotfix

### DIFF
--- a/apps/propositions/api/views.py
+++ b/apps/propositions/api/views.py
@@ -10,10 +10,17 @@ from apps.propositions.models import Proposition
 class PropositionViewSet(ModelViewSet):
     """API endpoint for viewing and editing propositions."""
 
-    queryset = Proposition.objects.filter(type='propositions.conclusion')
+    queryset = Proposition.objects.all()
     lookup_field = 'slug'
     serializer_class = PropositionDrfSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+    def list(self, request):
+        # get_absolute_url for occurrences currently returns a link with "propositions"
+        # instead of "occurrences". For now, we work around this by allowing retrieval
+        # of occurrences through the propositions API, but listing should exclude occurrences.
+        self.queryset = self.queryset.filter(type='propositions.conclusions')
+        return super().list(request)
 
 
 class PropositionModerationAPIView(RetrieveAPIView):


### PR DESCRIPTION
I noticed that a link on the SERP was bad.
https://modularhistory.com/propositions/formation-of-earths-first-oceans