### PR TITLE
poetry PATH fix

### DIFF
--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -1,4 +1,5 @@
 #!/bin/bash
+source "$HOME/.profile"
 
 # For debugging:
 echo "Successfully pulled to $(pwd)."

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -19,22 +19,23 @@ echo "$staged_files" | grep -E --quiet ".+.py" && {
     # Autoformat and lint Python code.
     poetry --quiet && [[ -d ".venv" ]] && {
         comma_delimited_filepaths=$(echo "$staged_python_files" | tr '\n' ',')
+        space_delimited_filepaths=$(echo "$staged_python_files" | tr '\n' ' ')
         echo "Autoformatting Python code..."
         poetry run invoke qa.autoformat --filepaths "${comma_delimited_filepaths%,}"
-        for file in $staged_python_files; do
-            # Check types with mypy first, since mypy is faster than pytype.
-            # https://github.com/google/pytype#usage
-            poetry run mypy "$file" || {
-                echo "
-                    ${BOLD}Examine the error above. Should it be fixed?${NORMAL}
-                    Pytype may give more helpful output:
-                        poetry run pytype --output .cache/pytype $file
-                "
-            }
-        done
-        for file in $staged_python_files; do
-            poetry run flake8 "$file" || linting_failed=true
-        done
+
+        # Check types with mypy first, since mypy is faster than pytype.
+        # https://github.com/google/pytype#usage
+        poetry run mypy "$space_delimited_filepaths" || {
+            echo "
+                ${BOLD}Examine the error above. Should it be fixed?${NORMAL}
+                Pytype may give more helpful output:
+                    poetry run pytype --output .cache/pytype $file
+            "
+        }
+
+
+        poetry run flake8 "$space_delimited_filepaths" || linting_failed=true
+
         if [[ "$linting_failed" = true ]]; then
             echo "
                 ${RED}Please fix the issues identified above, then recommit.${NORMAL}

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/bash
+source "$HOME/.profile"
 
 RED=$(tput setaf 1)
 BOLD=$(tput bold)
@@ -16,7 +17,7 @@ echo "Linting Python code..."
 echo "$staged_files" | grep -E --quiet ".+.py" && {
     staged_python_files=$(echo "$staged_files" | grep -E ".+.py")
     # Autoformat and lint Python code.
-    poetry --help &>/dev/null && [[ -d ".venv" ]] && {
+    poetry --quiet && [[ -d ".venv" ]] && {
         comma_delimited_filepaths=$(echo "$staged_python_files" | tr '\n' ',')
         echo "Autoformatting Python code..."
         poetry run invoke qa.autoformat --filepaths "${comma_delimited_filepaths%,}"


### PR DESCRIPTION
At least in my environment, and maybe in others, poetry commands in our git hooks were not running since `poetry` was not in `PATH`. I think this is because my IDE does not currently run the hooks with the virtual environment activated.