### PR TITLE
Explicitly set poetry install path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -306,14 +306,15 @@ if [[ ! "$(pyenv versions)" =~ "$PYTHON_VERSION" ]]; then
 fi
 
 # Install and configure Poetry.
+export POETRY_HOME="$HOME/.poetry"
 # shellcheck disable=SC2016
 poetry_init='export PATH="$HOME/.poetry/bin:$PATH"'
-poetry --version &>/dev/null || {
+poetry -q || {
   echo "Installing Poetry ..."
   # https://python-poetry.org/docs/#osx-linux-bashonwindows-install-instructions
   curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 -
   _append_to_sh_profile "$poetry_init"
-  poetry --version &>/dev/null || {
+  poetry -q || {
     _error "Failed to install Poetry (https://python-poetry.org/docs/#installation)."
   }
 }


### PR DESCRIPTION
I think it would be preferable to not override poetry's install path, but that would lead to inconsistencies between installation path on Mac and Unix. Any thoughts @iacobfred?

https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py
```py
"""
This script will install Poetry and its dependencies.

It does, in order:

  - Downloads the virtualenv package to a temporary directory and add it to sys.path.
  - Creates a virtual environment in the correct OS data dir which will be
      - `%APPDATA%\\pypoetry` on Windows
      -  ~/Library/Application Support/pypoetry on MacOS
      - `${XDG_DATA_HOME}/pypoetry` (or `~/.local/share/pypoetry` if it's not set) on UNIX systems
      - In `${POETRY_HOME}` if it's set.
  - Installs the latest or given version of Poetry inside this virtual environment.
  - Installs a `poetry` script in the Python user directory (or `${POETRY_HOME/bin}` if `POETRY_HOME` is set).
"""
```